### PR TITLE
Miscellaneous patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 CMakeCache.txt
 CMakeFiles/
-MakeFile
+Makefile
 cmake_install.cmake
 xva-img

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -83,7 +83,7 @@ bool Disk::Export(const std::string& diskpath)
 	if (parts.empty())
 		throw std::runtime_error("directory " + m_path + " is empty");
 
-	FILE* fp = fopen(diskpath.c_str(), "w");
+	FILE* fp = fopen(diskpath.c_str(), "wb");
 	if (!fp)
 		throw std::runtime_error("unable to open " + diskpath);
 
@@ -200,7 +200,7 @@ bool Disk::Import(const std::string& diskpath)
 	if (files != 0)
 		throw std::runtime_error("directory " + m_path + " is not empty");
 
-	FILE* fp = fopen(diskpath.c_str(), "r");
+	FILE* fp = fopen(diskpath.c_str(), "rb");
 	if (!fp)
 		throw std::runtime_error("unable to open " + diskpath);
 

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -72,7 +72,8 @@ bool Disk::Export(const std::string& diskpath)
 	while((de=readdir(dp)) != NULL)
 	{
 		unsigned int part;
-		if (strlen(de->d_name) == 8 && sscanf(de->d_name, "%u", &part))
+		int parsed = -1;
+		if (strlen(de->d_name) == 8 && sscanf(de->d_name, "%u%n", &part, &parsed) && parsed == 8)
 		{
 			parts.insert(part);
 		}

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -91,10 +91,11 @@ bool Disk::Export(const std::string& diskpath)
 	if (m_verbose)
 		progress.Start();
 
-	for(unsigned int i = 0; i <= (*parts.rbegin()); i++)
+	unsigned int const last = *parts.rbegin();
+	for(unsigned int i = 0; i <= last; i++)
 	{
 		if (m_verbose)
-			progress.Update(((float)i / *parts.rbegin())*100);
+			progress.Update(((float)i / last)*100);
 
 		if (parts.find(i) != parts.end())
 		{

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -98,7 +98,7 @@ void XVAPackage::AddDir(const std::string& path)
 bool XVAPackage::Write(const std::string& file)
 	noexcept(false)
 {
-	FILE* fp = fopen(file.c_str(), "w");
+	FILE* fp = fopen(file.c_str(), "wb");
 	if (!fp)
 		throw std::runtime_error("unable to open " + file);
 

--- a/src/package.cpp
+++ b/src/package.cpp
@@ -161,7 +161,7 @@ bool XVAPackage::Write(const std::string& file)
 		ptr += 8;
 		snprintf(ptr, 8, "%07d", 0);
 		ptr += 8;
-		snprintf(ptr, 12, "%011lo", data.size());
+		snprintf(ptr, 12, "%011lo", static_cast<long unsigned>(data.size()));
 		ptr += 12;
 		snprintf(ptr, 12, "%011d", 0);
 		ptr += 12;

--- a/src/readfile.cpp
+++ b/src/readfile.cpp
@@ -38,7 +38,7 @@
 
 bool XVA::ReadFile(const std::string& path, std::string& result)
 {
-	FILE* fp = fopen(path.c_str(), "r");
+	FILE* fp = fopen(path.c_str(), "rb");
 
  	if (!fp)
 		return false;

--- a/src/writefile.cpp
+++ b/src/writefile.cpp
@@ -38,7 +38,7 @@
 
 bool XVA::WriteFile(const std::string& path, const std::string& data)
 {
-	FILE* fp = fopen(path.c_str(), "w");
+	FILE* fp = fopen(path.c_str(), "wb");
 
 	if (!fp)
 		return false;

--- a/src/xxh64.cpp
+++ b/src/xxh64.cpp
@@ -47,7 +47,7 @@ std::string XVA::XXH64(const std::string& input)
 	XXH64_canonicalFromHash((XXH64_canonical_t *)digest, int_digest);
 	XXH64_freeState(state);
 
-	char digest_chars[16];
+	char digest_chars[17];
 	for (int i = 0, j = 0; i < 8; i++) {
 		unsigned char c;
 		c = (digest[i] >> 4) & 0xf;
@@ -57,7 +57,6 @@ std::string XVA::XXH64(const std::string& input)
 		c = (c > 9) ? c + 'A' - 10 : c + '0';
 		digest_chars[j++] = c;
 	}
-	std::string hexdigest(digest_chars);
-	hexdigest.resize(16);
-	return hexdigest;
+	digest_chars[16] = '\0';
+	return std::string(digest_chars);
 }


### PR DESCRIPTION
Hi,
  the proposed patches are quite independent 

1. Better filter for chunk files, avoid picking up wrong files
2. Open files as binary if needed, compatibility issue
3. Fix filename typo (MakeFile -> Makefile)
4. Avoid small buffer overflows computing xxhash
5. Avoid type format mismatch on Windows 64
6. Cache last part value

I managed to test the program on Windows compiled with MingW (which provides `dirent.h` header), at least exporting the disk.